### PR TITLE
enable permalinks

### DIFF
--- a/index.html
+++ b/index.html
@@ -397,10 +397,7 @@
       return link;
     }
 
-    var plotElements = "";
-
     function addToPlot(type, key, value) {
-      plotElements += type + "," + key + "," + value + ";";
       var tagDescription = (type === '***' ? '' : type + ' ') + key + (value ? '=' + value : '');
       fetch(getTaghistoryAPILink(type, key, value))
       .then(function(d) { return d.json(); })
@@ -428,6 +425,11 @@
         // trigger chart reset if it hasn't been zoomed yet
         if (view.signal('resetable') == 0) view.signal('reset', Math.random());
         view.update();
+
+        // update permalink
+        var permalinkPart = type + "," + key + "," + value + ";";
+        var permalinkElement = document.getElementById('permalink');
+        permalinkElement.href += permalinkPart;
 
 
         fetch(getTaginfoAPILink(key, value))
@@ -497,12 +499,6 @@
         var value = document.getElementById('value').value;
         addToPlot(type, key, value);
       });
-
-      document.getElementById('permalink').addEventListener('click', function(e) {
-        e.preventDefault();
-        document.location.hash = plotElements;
-      });
-
     });
 
   </script>

--- a/index.html
+++ b/index.html
@@ -465,7 +465,7 @@
       }
       return imageResult;
     }
-    
+
     function loadFromHash() {
       if (document.location.hash == "") {
         return;
@@ -487,18 +487,18 @@
         addToPlot(t,k,v);
       }
     }
-    
+
     document.addEventListener("DOMContentLoaded", function() {
       loadFromHash();
-	  
-	  document.getElementById('form').addEventListener('submit', function(e) {
-      e.preventDefault();
-      var type  = document.getElementById('type').value;
-      var key   = document.getElementById('key').value;
-      var value = document.getElementById('value').value;
-      addToPlot(type,key,value);
+
+      document.getElementById('form').addEventListener('submit', function(e) {
+        e.preventDefault();
+        var type  = document.getElementById('type').value;
+        var key   = document.getElementById('key').value;
+        var value = document.getElementById('value').value;
+        addToPlot(type,key,value);
       });
-	
+  
       document.getElementById('permalink').addEventListener('click', function(e) {
         e.preventDefault();
         document.location.hash = plotElements;

--- a/index.html
+++ b/index.html
@@ -429,8 +429,12 @@
         view.update();
 
         // update permalink
-        var permalinkPart = type + permalinkRequestSeparator + key + permalinkRequestSeparator + value + permalinkTagSeparator;
+        var permalinkPart = permalinkTagSeparator + type + permalinkRequestSeparator + key + permalinkRequestSeparator + value;
         var permalinkElement = document.getElementById('permalink');
+        if (permalinkElement.href.substr(-1) == '#') {
+          // skip separator for first tag in permalink
+          permalinkPart = permalinkPart.substring(1);
+        }
         permalinkElement.href += permalinkPart;
         window.history.replaceState(null, "", permalinkElement.href);
 

--- a/index.html
+++ b/index.html
@@ -397,11 +397,10 @@
       return link;
     }
 
-    document.getElementById('form').addEventListener('submit', function(e) {
-      e.preventDefault();
-      var type  = document.getElementById('type').value;
-      var key   = document.getElementById('key').value;
-      var value = document.getElementById('value').value;
+    var plotElements = "";
+
+    function addToPlot(type,key,value) {
+      plotElements += type+","+key+","+value+";";
       var tagDescription = (type === '***' ? '' : type+' ')+key+(value ? '='+value : '');
       fetch(getTaghistoryAPILink(type, key, value))
       .then(function(d) { return d.json(); })
@@ -451,7 +450,7 @@
         })
       })
       .catch(function(error) { console.error(error); });
-    });
+    }
 
     function exportImage(format) {
       var resetableValue = view.signal('resetable');
@@ -466,12 +465,55 @@
       }
       return imageResult;
     }
+    
+    function loadFromHash() {
+      if (document.location.hash == "") {
+        return;
+      }
+      var elements_to_add = document.location.hash.split("#")[1].split(";");
+      for(i=0;i<elements_to_add.length;i++) {
+        // defend against trailing semicolon/multiple semicolons
+        if (elements_to_add[i].length == 0) {
+          continue;
+        }
+        var tkv = elements_to_add[i].split(",");
+        // treat empty type as "***"
+        var t = (tkv[0] == "" ? "***" : tkv[0]);
+        // key must be given and is used as-is
+        var k = tkv[1];
+        // treat missing value as no value
+        var v = (tkv.length == 3 ? tkv[2] : "")
+        //console.log("t="+t+",k="+k+",v="+v);
+        addToPlot(t,k,v);
+      }
+    }
+    
+    document.addEventListener("DOMContentLoaded", function() {
+      loadFromHash();
+	  
+	  document.getElementById('form').addEventListener('submit', function(e) {
+      e.preventDefault();
+      var type  = document.getElementById('type').value;
+      var key   = document.getElementById('key').value;
+      var value = document.getElementById('value').value;
+      addToPlot(type,key,value);
+      });
+	
+      document.getElementById('permalink').addEventListener('click', function(e) {
+        e.preventDefault();
+        document.location.hash = plotElements;
+      });
+
+    });
 
   </script>
   <p>
     download graph as
     <a href="#" download="taghistory.svg" onmousedown="this.href=exportImage('svg')">svg</a> /
     <a href="#" download="taghistory.png" onmousedown="this.href=exportImage('png')">png</a>
+  </p>
+  <p>
+    <a href="#" id="permalink">permalink</a>
   </p>
   <p>
     Data © <a href="https://www.openstreetmap.org/copyright">OpenStreetMap contributors</a> (<a href="http://opendatacommons.org/licenses/odbl/1.0/">ODbL</a>).

--- a/index.html
+++ b/index.html
@@ -26,8 +26,8 @@
     var dataUpdateTags = +(new Date("2018-06-12T23:59:59Z"));
     var dataUpdateTagKeys = +(new Date("2019-02-16T23:59:59Z"));
     var osmBirth = +(new Date("2007-10-07T00:00:00Z"));
-    var permalinkTagSeparator = ";";
-    var permalinkRequestSeparator = ",";
+    var permalinkTagSeparator = "&";
+    var permalinkRequestSeparator = "/";
     var spec = {
       "width": 1000,
       "height": 600,

--- a/index.html
+++ b/index.html
@@ -399,9 +399,9 @@
 
     var plotElements = "";
 
-    function addToPlot(type,key,value) {
-      plotElements += type+","+key+","+value+";";
-      var tagDescription = (type === '***' ? '' : type+' ')+key+(value ? '='+value : '');
+    function addToPlot(type, key, value) {
+      plotElements += type + "," + key + "," + value + ";";
+      var tagDescription = (type === '***' ? '' : type + ' ') + key + (value ? '=' + value : '');
       fetch(getTaghistoryAPILink(type, key, value))
       .then(function(d) { return d.json(); })
       .then(function(d) {
@@ -471,20 +471,19 @@
         return;
       }
       var elements_to_add = document.location.hash.split("#")[1].split(";");
-      for(i=0;i<elements_to_add.length;i++) {
+      for(i = 0; i < elements_to_add.length; i++) {
         // defend against trailing semicolon/multiple semicolons
         if (elements_to_add[i].length == 0) {
           continue;
         }
         var tkv = elements_to_add[i].split(",");
         // treat empty type as "***"
-        var t = (tkv[0] == "" ? "***" : tkv[0]);
+        var type  = tkv[0] == "" ? "***" : tkv[0];
         // key must be given and is used as-is
-        var k = tkv[1];
+        var key   = tkv[1];
         // treat missing value as no value
-        var v = (tkv.length == 3 ? tkv[2] : "")
-        //console.log("t="+t+",k="+k+",v="+v);
-        addToPlot(t,k,v);
+        var value = tkv.length == 3 ? tkv[2] : "";
+        addToPlot(type, key, value);
       }
     }
 
@@ -496,9 +495,9 @@
         var type  = document.getElementById('type').value;
         var key   = document.getElementById('key').value;
         var value = document.getElementById('value').value;
-        addToPlot(type,key,value);
+        addToPlot(type, key, value);
       });
-  
+
       document.getElementById('permalink').addEventListener('click', function(e) {
         e.preventDefault();
         document.location.hash = plotElements;

--- a/index.html
+++ b/index.html
@@ -26,6 +26,8 @@
     var dataUpdateTags = +(new Date("2018-06-12T23:59:59Z"));
     var dataUpdateTagKeys = +(new Date("2019-02-16T23:59:59Z"));
     var osmBirth = +(new Date("2007-10-07T00:00:00Z"));
+    var permalinkTagSeparator = ";";
+    var permalinkRequestSeparator = ",";
     var spec = {
       "width": 1000,
       "height": 600,
@@ -427,7 +429,7 @@
         view.update();
 
         // update permalink
-        var permalinkPart = type + "," + key + "," + value + ";";
+        var permalinkPart = type + permalinkRequestSeparator + key + permalinkRequestSeparator + value + permalinkTagSeparator;
         var permalinkElement = document.getElementById('permalink');
         permalinkElement.href += permalinkPart;
         window.history.replaceState(null, "", permalinkElement.href);
@@ -477,8 +479,8 @@
       if (hash == "") {
         return;
       }
-      var tagsFromHash = hash.split(";");
-      var tkv = tagsFromHash.shift().split(",");
+      var tagsFromHash = hash.split(permalinkTagSeparator);
+      var tkv = tagsFromHash.shift().split(permalinkRequestSeparator);
       // treat empty type as "***"
       var type  = tkv[0] == "" ? "***" : tkv[0];
       // key must be given and is used as-is
@@ -487,7 +489,7 @@
       var value = tkv.length == 3 ? tkv[2] : "";
       addToPlot(type, key, value, function() {
         // recursively call addToPlot for further tags, if any
-        loadFromHash(tagsFromHash.join(";"));
+        loadFromHash(tagsFromHash.join(permalinkTagSeparator));
       });
     }
 

--- a/index.html
+++ b/index.html
@@ -430,7 +430,7 @@
         var permalinkPart = type + "," + key + "," + value + ";";
         var permalinkElement = document.getElementById('permalink');
         permalinkElement.href += permalinkPart;
-
+        window.history.replaceState(null, "", permalinkElement.href);
 
         fetch(getTaginfoAPILink(key, value))
         .then(function(d) { return d.json(); })

--- a/index.html
+++ b/index.html
@@ -397,7 +397,7 @@
       return link;
     }
 
-    function addToPlot(type, key, value) {
+    function addToPlot(type, key, value, doneCallback) {
       var tagDescription = (type === '***' ? '' : type + ' ') + key + (value ? '=' + value : '');
       fetch(getTaghistoryAPILink(type, key, value))
       .then(function(d) { return d.json(); })
@@ -431,6 +431,11 @@
         var permalinkElement = document.getElementById('permalink');
         permalinkElement.href += permalinkPart;
         window.history.replaceState(null, "", permalinkElement.href);
+
+        // trigger doneCallback
+        if (doneCallback !== undefined) {
+          doneCallback.call();
+        }
 
         fetch(getTaginfoAPILink(key, value))
         .then(function(d) { return d.json(); })
@@ -468,29 +473,26 @@
       return imageResult;
     }
 
-    function loadFromHash() {
-      if (document.location.hash == "") {
+    function loadFromHash(hash) {
+      if (hash == "") {
         return;
       }
-      var elements_to_add = document.location.hash.split("#")[1].split(";");
-      for(i = 0; i < elements_to_add.length; i++) {
-        // defend against trailing semicolon/multiple semicolons
-        if (elements_to_add[i].length == 0) {
-          continue;
-        }
-        var tkv = elements_to_add[i].split(",");
-        // treat empty type as "***"
-        var type  = tkv[0] == "" ? "***" : tkv[0];
-        // key must be given and is used as-is
-        var key   = tkv[1];
-        // treat missing value as no value
-        var value = tkv.length == 3 ? tkv[2] : "";
-        addToPlot(type, key, value);
-      }
+      var tagsFromHash = hash.split(";");
+      var tkv = tagsFromHash.shift().split(",");
+      // treat empty type as "***"
+      var type  = tkv[0] == "" ? "***" : tkv[0];
+      // key must be given and is used as-is
+      var key   = tkv[1];
+      // treat missing value as no value
+      var value = tkv.length == 3 ? tkv[2] : "";
+      addToPlot(type, key, value, function() {
+        // recursively call addToPlot for further tags, if any
+        loadFromHash(tagsFromHash.join(";"));
+      });
     }
 
     document.addEventListener("DOMContentLoaded", function() {
-      loadFromHash();
+      loadFromHash(document.location.hash.substring(1));
 
       document.getElementById('form').addEventListener('submit', function(e) {
         e.preventDefault();


### PR DESCRIPTION
This extracts a method to add elements to the plot, which in turn enables us to manage permalinks by calling that function with parameters from the URL hash. Also includes a permalink html element which will set the document hash to a value that can then be shared. Fixes issue GIScience/oshdb#6